### PR TITLE
Output log to stdout

### DIFF
--- a/httpd.conf
+++ b/httpd.conf
@@ -179,7 +179,8 @@ DocumentRoot "/var/www/html"
 # logged here.  If you *do* define an error logfile for a <VirtualHost>
 # container, that host's errors will be logged there and not here.
 #
-ErrorLog "logs/error_log"
+#ErrorLog "logs/error_log"
+ErrorLog "|/usr/bin/cat"
 
 #
 # LogLevel: Control the number of messages logged to the error_log.
@@ -214,7 +215,8 @@ LogLevel warn
     # If you prefer a logfile with access, agent, and referer information
     # (Combined Logfile Format) you can use the following directive.
     #
-    CustomLog "logs/access_log" combined
+    #CustomLog "logs/access_log" combined
+    CustomLog "|/usr/bin/cat" combined
 </IfModule>
 
 <IfModule alias_module>


### PR DESCRIPTION
httpd outputs error and access log into /var/log/httpd/ by
default. However, on container or OpenShift env, the logs should be
output to stdout of the process so it could be visible by users, also
rotated by docker's default function.

From this reason, this patch changes the path of the logs to standard
output.